### PR TITLE
issue #14 Optimize production build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
+# osx
+.DS_Store
+
+# javascript
 node_modules
 coverage
 dist

--- a/package.json
+++ b/package.json
@@ -59,7 +59,8 @@
   "babel": {
     "presets": [
       "es2015"
-    ]
+    ],
+    "comments": false
   },
   "eslintConfig": {
     "parserOptions": {


### PR DESCRIPTION
Removes comments from the production build reducing the size of the `dist` files by over 50%.

Fixes #14 